### PR TITLE
Refactor/specifig usage of region

### DIFF
--- a/charts/v1beta1/irsa/CHANGELOG.md
+++ b/charts/v1beta1/irsa/CHANGELOG.md
@@ -26,4 +26,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.1.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/irsa-0.1.0-v1beta1/charts/v1beta1/irsa
 [0.2.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/irsa-0.2.0-v1beta1/charts/v1beta1/irsa
-
+[1.0.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/irsa-1.0.0-v1beta1/charts/v1beta1/irsa

--- a/charts/v1beta1/irsa/CHANGELOG.md
+++ b/charts/v1beta1/irsa/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0]
+
+### Changed
+
+* Read parameter `region` from global wadtfy-env instead of tenant-env
+
 ## [0.2.0]
 
 ### Replaced

--- a/charts/v1beta1/irsa/Chart.yaml
+++ b/charts/v1beta1/irsa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Helm chart for installing a custom irsa crossplane xrd.
 name: irsa
-version: 0.2.0-v1beta1
+version: 1.0.0-v1beta1
 home: https://github.com/DVPE-cloud/wadtfy-custom-components
 keywords:
   - crossplane

--- a/charts/v1beta1/irsa/README.md
+++ b/charts/v1beta1/irsa/README.md
@@ -1,6 +1,6 @@
 # irsa
 
-![Version: 0.2.0-v1beta1](https://img.shields.io/badge/Version-0.2.0--v1beta1-informational?style=flat-square)
+![Version: 1.0.0-v1beta1](https://img.shields.io/badge/Version-1.0.0--v1beta1-informational?style=flat-square)
 
 Helm chart for installing a custom irsa crossplane xrd.
 

--- a/charts/v1beta1/irsa/templates/irsa-system-composition.yaml
+++ b/charts/v1beta1/irsa/templates/irsa-system-composition.yaml
@@ -44,7 +44,7 @@ spec:
           fromFieldPath: "iamOidcProviderId"
           toFieldPath: "spec.iamOidcProviderId"
         - type: FromEnvironmentFieldPath
-          fromFieldPath: "region"
+          fromFieldPath: "awsRegion"
           toFieldPath: "spec.region"
         - type: FromEnvironmentFieldPath
           fromFieldPath: "providerConfig"

--- a/charts/v1beta1/irsa/templates/irsa-tenant-composition.yaml
+++ b/charts/v1beta1/irsa/templates/irsa-tenant-composition.yaml
@@ -44,7 +44,7 @@ spec:
           fromFieldPath: "iamOidcProviderId"
           toFieldPath: "spec.iamOidcProviderId"
         - type: FromEnvironmentFieldPath
-          fromFieldPath: "region"
+          fromFieldPath: "awsRegion"
           toFieldPath: "spec.region"
         - type: FromEnvironmentFieldPath
           fromFieldPath: "providerConfig"

--- a/charts/v1beta1/tenant/CHANGELOG.md
+++ b/charts/v1beta1/tenant/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+
+### Removed
+* Parameter `region`
+
+### Changed
+* Read `region` from wadtfy-env instead of setting it as an explicit parameter in xsecretstore
+* Read `kubernetesproviderconf` from wadtfy-env instead of setting it as an explicit parameter in xsecretstore
+
 ## [1.2.0]
 
 ### Replaced

--- a/charts/v1beta1/tenant/CHANGELOG.md
+++ b/charts/v1beta1/tenant/CHANGELOG.md
@@ -63,4 +63,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-1.0.0-v1beta1/charts/v1beta1/tenant
 [1.1.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-1.1.0-v1beta1/charts/v1beta1/tenant
 [1.2.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-1.2.0-v1beta1/charts/v1beta1/tenant
-
+[2.0.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-2.0.0-v1beta1/charts/v1beta1/tenant

--- a/charts/v1beta1/tenant/Chart.yaml
+++ b/charts/v1beta1/tenant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Helm chart for installing a custom tenant crossplane xrd.
 name: tenant
-version: 1.2.0-v1beta1
+version: 2.0.0-v1beta1
 home: https://github.com/DVPE-cloud/wadtfy-custom-components
 keywords:
   - crossplane

--- a/charts/v1beta1/tenant/README.md
+++ b/charts/v1beta1/tenant/README.md
@@ -1,6 +1,6 @@
 # tenant
 
-![Version: 1.2.0-v1beta1](https://img.shields.io/badge/Version-1.2.0--v1beta1-informational?style=flat-square)
+![Version: 2.0.0-v1beta1](https://img.shields.io/badge/Version-2.0.0--v1beta1-informational?style=flat-square)
 
 Helm chart for installing a custom tenant crossplane xrd.
 

--- a/charts/v1beta1/tenant/templates/secret-store/secretstore-composition.yaml
+++ b/charts/v1beta1/tenant/templates/secret-store/secretstore-composition.yaml
@@ -60,8 +60,7 @@ spec:
             - type: string
               string:
                 fmt: "secret-store-%s"
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: "irsaTenantCompositionRef"
+        - fromFieldPath: "spec.irsaCompositionRef"
           toFieldPath: "spec.forProvider.manifest.spec.compositionRef.name"
         - fromFieldPath: "spec.awsAccountId"
           toFieldPath: "spec.forProvider.manifest.spec.policyDocument"

--- a/charts/v1beta1/tenant/templates/secret-store/secretstore-composition.yaml
+++ b/charts/v1beta1/tenant/templates/secret-store/secretstore-composition.yaml
@@ -6,6 +6,11 @@ metadata:
     crossplane.io/xrd: xsecretstores.wadtfy.bmwgroup.net
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
+  environment:
+    environmentConfigs:
+      - type: Reference
+        ref:
+          name: wadtfy-env
   compositeTypeRef:
     apiVersion: wadtfy.bmwgroup.net/v1beta1
     kind: XSecretStore
@@ -55,7 +60,8 @@ spec:
             - type: string
               string:
                 fmt: "secret-store-%s"
-        - fromFieldPath: "spec.irsaCompositionRef"
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: "irsaTenantCompositionRef"
           toFieldPath: "spec.forProvider.manifest.spec.compositionRef.name"
         - fromFieldPath: "spec.awsAccountId"
           toFieldPath: "spec.forProvider.manifest.spec.policyDocument"
@@ -78,7 +84,8 @@ spec:
                       }
                     ]
                   }
-        - fromFieldPath: "spec.providerConfigKubernetes"
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: "providerConfigKubernetes"
           toFieldPath: "spec.providerConfigRef.name"
     - name: SecretStore
       base:
@@ -138,7 +145,9 @@ spec:
               # resource.
               fmt: "%s-secret-store-%s"
           toFieldPath: "spec.forProvider.manifest.spec.provider.aws.auth.jwt.serviceAccountRef.name"
-        - fromFieldPath: "spec.region"
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: "awsRegion"
           toFieldPath: "spec.forProvider.manifest.spec.provider.aws.region"
-        - fromFieldPath: "spec.providerConfigKubernetes"
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: "providerConfigKubernetes"
           toFieldPath: "spec.providerConfigRef.name"

--- a/charts/v1beta1/tenant/templates/secret-store/secretstore-xrd.yaml
+++ b/charts/v1beta1/tenant/templates/secret-store/secretstore-xrd.yaml
@@ -18,18 +18,9 @@ spec:
             spec:
               type: object
               properties:
-                irsaCompositionRef:
-                  type: string
-                  description: "The name of the IRSA Composition Ref that should be used for IRSA creation. This value is stored in the global wadtfy-env EnvironmentConfig."
-                providerConfigKubernetes:
-                  type: string
-                  description: "The name of the K8S ProviderConfig. This value is stored in the global wadtfy-env EnvironmentConfig."
                 product:
                   type: string
                   description: "Tenant's product name."
-                region:
-                  type: string
-                  description: "Tenant's AWS Account region."
                 awsAccountId:
                   type: string
                   description: "The AWS account id for which to create namespaces on the Kubernetes cluster."
@@ -37,9 +28,6 @@ spec:
                   type: string
                   description: "Tenant's specific namespace where to create dependent resources for external secrets."
               required:
-                - irsaCompositionRef
-                - providerConfigKubernetes
                 - product
-                - region
                 - awsAccountId
                 - namespace

--- a/charts/v1beta1/tenant/templates/secret-store/secretstore-xrd.yaml
+++ b/charts/v1beta1/tenant/templates/secret-store/secretstore-xrd.yaml
@@ -18,6 +18,9 @@ spec:
             spec:
               type: object
               properties:
+                irsaCompositionRef:
+                  type: string
+                  description: "The name of the IRSA Composition Ref that should be used for IRSA creation. This value is stored in the global wadtfy-env EnvironmentConfig."
                 product:
                   type: string
                   description: "Tenant's product name."
@@ -28,6 +31,7 @@ spec:
                   type: string
                   description: "Tenant's specific namespace where to create dependent resources for external secrets."
               required:
+                - irsaCompositionRef
                 - product
                 - awsAccountId
                 - namespace

--- a/charts/v1beta1/tenant/templates/tenant-default-composition.yaml
+++ b/charts/v1beta1/tenant/templates/tenant-default-composition.yaml
@@ -160,9 +160,6 @@ spec:
         - type: FromEnvironmentFieldPath
           fromFieldPath: "irsaTenantCompositionRef"
           toFieldPath: "spec.irsaCompositionRef"
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: "providerConfigKubernetes"
-          toFieldPath: "spec.providerConfigKubernetes"
         - fromFieldPath: "spec.product"
           toFieldPath: "spec.product"
         - fromFieldPath: "spec.awsAccountId"

--- a/charts/v1beta1/tenant/templates/tenant-default-composition.yaml
+++ b/charts/v1beta1/tenant/templates/tenant-default-composition.yaml
@@ -125,7 +125,6 @@ spec:
               data:
                 product:
                 awsAccountId:
-                region:
                 providerConfig:
           providerConfigRef:
             name:
@@ -148,8 +147,6 @@ spec:
           toFieldPath: "spec.forProvider.manifest.data.awsAccountId"
         - fromFieldPath: "spec.product"
           toFieldPath: "spec.forProvider.manifest.data.product"
-        - fromFieldPath: "spec.region"
-          toFieldPath: "spec.forProvider.manifest.data.region"
         - fromFieldPath: "status.providerConfig"
           toFieldPath: "spec.forProvider.manifest.data.providerConfig"
         - type: FromEnvironmentFieldPath
@@ -168,8 +165,6 @@ spec:
           toFieldPath: "spec.providerConfigKubernetes"
         - fromFieldPath: "spec.product"
           toFieldPath: "spec.product"
-        - fromFieldPath: "spec.region"
-          toFieldPath: "spec.region"
         - fromFieldPath: "spec.awsAccountId"
           toFieldPath: "spec.awsAccountId"
         - fromFieldPath: "spec.namespace"

--- a/charts/v1beta1/tenant/templates/tenant-system-composition.yaml
+++ b/charts/v1beta1/tenant/templates/tenant-system-composition.yaml
@@ -122,7 +122,6 @@ spec:
               data:
                 product: "wadtfy"
                 awsAccountId:
-                region:
                 providerConfig:
           providerConfigRef:
             name:
@@ -145,9 +144,6 @@ spec:
         - type: FromEnvironmentFieldPath
           fromFieldPath: "eksAccountID"
           toFieldPath: "spec.forProvider.manifest.data.awsAccountId"
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: "awsRegion"
-          toFieldPath: "spec.forProvider.manifest.data.region"
         - fromFieldPath: "status.providerConfig"
           toFieldPath: "spec.forProvider.manifest.data.providerConfig"
         - type: FromEnvironmentFieldPath
@@ -164,9 +160,6 @@ spec:
         - type: FromEnvironmentFieldPath
           fromFieldPath: "product"
           toFieldPath: "spec.product"
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: "awsRegion"
-          toFieldPath: "spec.region"
         - type: FromEnvironmentFieldPath
           fromFieldPath: "eksAccountID"
           toFieldPath: "spec.awsAccountId"

--- a/charts/v1beta1/tenant/templates/tenant-system-composition.yaml
+++ b/charts/v1beta1/tenant/templates/tenant-system-composition.yaml
@@ -163,8 +163,5 @@ spec:
         - type: FromEnvironmentFieldPath
           fromFieldPath: "eksAccountID"
           toFieldPath: "spec.awsAccountId"
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: "providerConfigKubernetes"
-          toFieldPath: "spec.providerConfigKubernetes"
         - fromFieldPath: "spec.namespace"
           toFieldPath: "spec.namespace"

--- a/charts/v1beta1/tenant/templates/tenant-xrd.yaml
+++ b/charts/v1beta1/tenant/templates/tenant-xrd.yaml
@@ -28,9 +28,6 @@ spec:
                 product:
                   type: string
                   description: "Tenant's product name."
-                region:
-                  type: string
-                  description: "Tenant's AWS Account region."
                 awsAccountId:
                   type: string
                   description: "The AWS account id for which to create namespaces on the Kubernetes cluster."

--- a/charts/v1beta1/tenantfilesystem/CHANGELOG.md
+++ b/charts/v1beta1/tenantfilesystem/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0]
 ### Changed
 
-* Add parameter `region`
-* Remove reading `region` from TenantEnv
+* Add parameter `region` instead of reading it from TenantEnv
 
 ## [1.2.0]
 ### Fix
@@ -74,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Initial Version
 
+[2.0.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-filesystem-2.0.0-v1beta1/charts/v1beta1/tenantfilesystem
 [1.2.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-filesystem-1.2.0-v1beta1/charts/v1beta1/tenantfilesystem
 [1.1.1]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-filesystem-1.1.1-v1beta1/charts/v1beta1/tenantfilesystem
 [1.1.0]: https://github.com/DVPE-cloud/wadtfy-custom-components/tree/tenant-filesystem-1.1.0-v1beta1/charts/v1beta1/tenantfilesystem

--- a/charts/v1beta1/tenantfilesystem/CHANGELOG.md
+++ b/charts/v1beta1/tenantfilesystem/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+### Changed
+
+* Add parameter `region`
+* Remove reading `region` from TenantEnv
+
 ## [1.2.0]
 ### Fix
 

--- a/charts/v1beta1/tenantfilesystem/Chart.yaml
+++ b/charts/v1beta1/tenantfilesystem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.1"
 description: "Helm Chart for installing a custom tenantfilesystem xrd"
 name: tenant-filesystem
-version: 1.2.0-v1beta1
+version: 2.0.0-v1beta1
 home: https://github.com/DVPE-cloud/wadtfy-custom-components
 keywords:
   - crossplane

--- a/charts/v1beta1/tenantfilesystem/README.md
+++ b/charts/v1beta1/tenantfilesystem/README.md
@@ -1,6 +1,6 @@
 # tenant-filesystem
 
-![Version: 1.2.0-v1beta1](https://img.shields.io/badge/Version-1.2.0--v1beta1-informational?style=flat-square)
+![Version: 2.0.0-v1beta1](https://img.shields.io/badge/Version-2.0.0--v1beta1-informational?style=flat-square)
 
 Helm Chart for installing a custom tenantfilesystem xrd
 

--- a/charts/v1beta1/tenantfilesystem/templates/tenantfilesystem-composition.yaml
+++ b/charts/v1beta1/tenantfilesystem/templates/tenantfilesystem-composition.yaml
@@ -87,12 +87,6 @@ spec:
                 toType: string
         - fromFieldPath: "spec.product"
           toFieldPath: "spec.forProvider.tags[4].value"
-    - name: "region"
-      patches:
-        - fromFieldPath: "spec.region"
-          toFieldPath: "spec.forProvider.region"
-          policy:
-            fromFieldPath: Required
     - name: "deletionPolicy"
       patches:
         - fromFieldPath: "spec.deletionPolicy"
@@ -250,8 +244,6 @@ spec:
         - type: PatchSet
           patchSetName: "tags"
         - type: PatchSet
-          patchSetName: "region"
-        - type: PatchSet
           patchSetName: "deletionPolicy"
         - type: FromEnvironmentFieldPath
           fromFieldPath: "awsAccountId"
@@ -275,6 +267,8 @@ spec:
                       }
                     ]
                   }
+        - fromFieldPath: "spec.region"
+          toFieldPath: "spec.forProvider.region"
         - type: ToCompositeFieldPath
           fromFieldPath: "metadata.name"
           toFieldPath: "status.kmsKeyRefName"
@@ -317,9 +311,9 @@ spec:
         - type: PatchSet
           patchSetName: "tagsV2"
         - type: PatchSet
-          patchSetName: "region"
-        - type: PatchSet
           patchSetName: "deletionPolicy"
+        - fromFieldPath: "spec.region"
+          toFieldPath: "spec.forProvider.region"
         - fromFieldPath: "status.kmsKeyRefName"
           toFieldPath: "spec.forProvider.kmsKeyIdRef.name"
           policy:
@@ -569,14 +563,14 @@ spec:
         - type: PatchSet
           patchSetName: "tagsV2"
         - type: PatchSet
-          patchSetName: "region"
-        - type: PatchSet
           patchSetName: "deletionPolicy"
         - type: FromEnvironmentFieldPath
           fromFieldPath: "eksCidrIp"
           toFieldPath: "spec.forProvider.ingress[0].ipRanges[0].cidrIp"
           policy:
             fromFieldPath: Required
+        - fromFieldPath: "spec.region"
+          toFieldPath: "spec.forProvider.region"
         - fromFieldPath: "spec.vpcId"
           toFieldPath: "spec.forProvider.vpcId"
           policy:

--- a/charts/v1beta1/tenantfilesystem/templates/tenantfilesystem-composition.yaml
+++ b/charts/v1beta1/tenantfilesystem/templates/tenantfilesystem-composition.yaml
@@ -115,9 +115,6 @@ spec:
           fromFieldPath: "awsAccountId"
           toFieldPath: "spec.env.awsAccountId"
         - type: FromEnvironmentFieldPath
-          fromFieldPath: "region"
-          toFieldPath: "spec.env.region"
-        - type: FromEnvironmentFieldPath
           fromFieldPath: "providerConfig"
           toFieldPath: "spec.env.providerConfig"
         - type: FromEnvironmentFieldPath
@@ -137,11 +134,6 @@ spec:
         - type: ToCompositeFieldPath
           fromFieldPath: "spec.env.awsAccountId"
           toFieldPath: "spec.awsAccountId"
-          policy:
-            fromFieldPath: Required
-        - type: ToCompositeFieldPath
-          fromFieldPath: "spec.env.region"
-          toFieldPath: "spec.region"
           policy:
             fromFieldPath: Required
         - type: ToCompositeFieldPath
@@ -192,8 +184,7 @@ spec:
           toFieldPath: spec.providerConfigRef.name
         - type: PatchSet
           patchSetName: component-name
-        - type: FromEnvironmentFieldPath
-          fromFieldPath: region
+        - fromFieldPath: spec.region
           toFieldPath: spec.forProvider.values.components.global.region
         - fromFieldPath: spec.deletionPolicy
           toFieldPath: spec.forProvider.values.components.global.deletionPolicy

--- a/charts/v1beta1/tenantfilesystem/templates/tenantfilesystem-xrd.yaml
+++ b/charts/v1beta1/tenantfilesystem/templates/tenantfilesystem-xrd.yaml
@@ -101,6 +101,7 @@ spec:
                 - efsPerformanceMode
                 - efsThroughputMode
                 - storageClass
+                - region
             status:
               type: object
               properties:


### PR DESCRIPTION
This PR:
- removes the region parameter from xtenant
- references the region from the wadtfy-env in xsecretstore
- references the kubernetesproviderconf from the wadfy-env in xsecretstore
- requires the region parameter in xtenantfilesystem and references it instead of reading it from the tenant env